### PR TITLE
Escape quotes to fix #1

### DIFF
--- a/findDeletedPhotos.script
+++ b/findDeletedPhotos.script
@@ -31,7 +31,7 @@ repeat with i from 1 to length of photosToProcess
 	
 	tell application "Photos"
 		set photo to item i of photosToProcess
-		set filePath to do shell script "find '" & referencedFilesFolderName & "' -name '" & filename of photo & "'"
+		set filePath to do shell script "find \"" & referencedFilesFolderName & "\" -name \"" & filename of photo & "\""
 		if filePath is "" then
 			copy photo to end of deletedItems
 		end if


### PR DESCRIPTION
The shell script returns an error if the file name contains a quote and breaks the script.